### PR TITLE
Changed order of imports in example code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,9 @@ A reference implementation:
 
 ::
 
-    import boto3
     import sys
     from greenglacier import GreenGlacierUploader
+    import boto3
 
     glacier = boto3.resource('glacier')
     vault = glacier.Vault('-', 'vault name')


### PR DESCRIPTION
If we import boto3 BEFORE GreenGlacier, its raise and exception under Python36. See gevent/gevent/#1016 issue.